### PR TITLE
Add sshecret to *SSH* agent section

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ Please read the [contribution guidelines](CONTRIBUTING.md) if you want to contri
 
 * [ssh-ident](https://github.com/ccontavalli/ssh-ident) [![stars](https://img.shields.io/github/stars/ccontavalli/ssh-ident.svg?style=social&label=stars)](https://github.com/ccontavalli/ssh-ident) - Different agents and different keys for different projects, with `ssh`.
 * [oh-my-zsh/plugins/ssh-agent](https://github.com/robbyrussell/oh-my-zsh) [![stars](https://img.shields.io/github/stars/robbyrussell/oh-my-zsh.svg?style=social&label=stars)](https://github.com/robbyrussell/oh-my-zsh) - `ssh-agent` plugin for `zsh`.
+* [sshecret](https://github.com/thcipriani/sshecret) - Automatically create and manage multiple agents for multiple keys.
 
 ### Tools
 


### PR DESCRIPTION
Suggesting the addition of a tool I wrote called sshecret: https://github.com/thcipriani/sshecret

The tool is fairly similar to ssh-ident (which I didn't realize existed at the time I wrote sshecret); however, sshecret requires no additional configuration outside of the ~/.ssh/config file. Using the information in the user-specific ssh-config file, sshecret dynamically creates ssh-agents each containing only a single key.