### PR TITLE
Add sshpiper

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ Please read the [contribution guidelines](CONTRIBUTING.md) if you want to contri
 * [wssh](https://github.com/aluzzardi/wssh) [![stars](https://img.shields.io/github/stars/aluzzardi/wssh.svg?style=social&label=stars)](https://github.com/aluzzardi/wssh) - *SSH* to WebSockets Bridge.
 * [docker-volume-sshfs](https://github.com/vieux/docker-volume-sshfs) [![stars](https://img.shields.io/github/stars/vieux/docker-volume-sshfs.svg?style=social&label=stars)](https://github.com/vieux/docker-volume-sshfs) - `sshfs` docker volume plugin.
 * [quicssh](https://github.com/moul/quicssh) [![stars](https://img.shields.io/github/stars/moul/quicssh.svg?style=social&label=stars)](https://github.com/moul/quicssh) - QUIC proxy for SSH
+* [sshpiper](https://github.com/tg123/sshpiper) [![stars](https://img.shields.io/github/stars/tg123/sshpiper.svg?style=social&label=stars)](https://github.com/tg123/sshpiper) - The missing reverse proxy for ssh scp.
 
 ### Multiplexers
 


### PR DESCRIPTION
I added [sshpiper](https://github.com/tg123/sshpiper) to the list. It works as a reverse proxy for ssh, for example by transparently forwarding users to their own containers inside the host server.