### PR TITLE
feat: Add google/HIBA

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ Please read the [contribution guidelines](CONTRIBUTING.md) if you want to contri
 * [github-keygen](https://github.com/dolmen/github-keygen) [![stars](https://img.shields.io/github/stars/dolmen/github-keygen.svg?style=social&label=stars)](https://github.com/dolmen/github-keygen) - Easy creation of secure *SSH* configuration for your GitHub account(s).
 * [kr](https://github.com/KryptCo/kr) [![stars](https://img.shields.io/github/stars/dolmen/github-keygen.svg?style=social&label=stars)](https://github.com/KryptCo/kr) - Kr agent that route access request to the paired mobile phone where Kryptonite is installed.
 * [ServerAuth](https://serverauth.com) - Automatically sync SSH access across servers
+* [HIBA](https://github.com/google/hiba) [![stars](https://img.shields.io/github/stars/google/hiba.svg?style=social&label=stars)](https://github.com/google/hiba) - Central management of access to a fleet of machines without pushing authorized_users files.
 
 ### *SSH* agent
 


### PR DESCRIPTION
From the official repo description: "HIBA is a system built on top of regular OpenSSH certificate-based authentication that allows to manage flexible authorization of principals on pools of target hosts without the need to push customized authorized_users files periodically."

In other words: it generates SSH certificates with specific fields that are matched to local machine attributes to allow/disallow access for certain users and enforce restrictions.