### PR TITLE
Added Warpgate

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Please read the [contribution guidelines](CONTRIBUTING.md) if you want to contri
 * [x84](https://github.com/jquast/x84) [![stars](https://img.shields.io/github/stars/jquast/x84.svg?style=social&label=stars)](https://github.com/jquast/x84) - A *python* `telnet`/`ssh` server for modern *UTF-8* and classic *cp437* network virtual terminals. In spirit of classic software such as *ami/x*, *teleguard*, *renegade*, *iniquity*.
 * [teleport](https://github.com/gravitational/teleport) [![stars](https://img.shields.io/github/stars/gravitational/teleport.svg?style=social&label=stars)](https://github.com/gravitational/teleport) - Modern *SSH* server for clusters and teams.
 * [ShellHub](https://github.com/shellhub-io/shellhub) [![stars](https://img.shields.io/github/stars/shellhub-io/shellhub.svg?style=social&label=stars)](https://github.com/shellhub-io/shellhub) - A *SSH* gateway for remotely accessing any Linux device behind firewall and NAT.
+* [Warpgate](https://github.com/warp-tech/warpgate) [![stars](https://img.shields.io/github/stars/warp-tech/warpgate.svg?style=social&label=stars)](https://github.com/warp-tech/warpgate) - Smart SSH and HTTPS bastion/multiplexer that works with any SSH client.
 
 ### Network
 


### PR DESCRIPTION
Warpgate is a smart SSH & HTTPS bastion host for Linux that can be used with any SSH client.

* Set it up in your DMZ, add user accounts and easily assign them to specific hosts and URLs within the network.
* Warpgate will record every SSH session for you to view (live) and replay later through a built-in admin web UI.
* Not a jump host - forwards your connections straight to the target instead.
* 2FA support
* Single binary with no dependencies.
* Written in 100% safe Rust.